### PR TITLE
Fixnum deprecated - Ruby 2.4 compatibility

### DIFF
--- a/lib/colorable.rb
+++ b/lib/colorable.rb
@@ -12,10 +12,10 @@ module Colorable
 
 end
 
-[String, Symbol, Array, Fixnum].each do |klass|
+[String, Symbol, Array, Integer].each do |klass|
   klass.class_eval do
     define_method(:to_color) do
-      Colorable::Color.new (klass==Fixnum ? self.to_s(16) : self)
+      Colorable::Color.new (klass==Integer ? self.to_s(16) : self)
     end
   end
 end

--- a/lib/colorable/color.rb
+++ b/lib/colorable/color.rb
@@ -121,7 +121,7 @@ module Colorable
     #
     # +other+ can be:
     #   Color object: apply minimum compositing with its RGBs.
-    #   Array of values or Fixnum: addiction applies based on its color mode.
+    #   Array of values or Integer: addiction applies based on its color mode.
     def +(other)
       case other
       when Color
@@ -135,7 +135,7 @@ module Colorable
     #
     # +other+ can be:
     #   Color object: apply maximum compositing with its RGBs.
-    #   Array of values or Fixnum: subtruction applies based on its color mode.
+    #   Array of values or Integer: subtruction applies based on its color mode.
     def -(other)
       case other
       when Color

--- a/lib/colorable/color_space.rb
+++ b/lib/colorable/color_space.rb
@@ -133,6 +133,7 @@ module Colorable
   class HSB < ColorSpace
     attr_accessor :hsb, :h, :s, :b
     def initialize(h=0,s=0,b=0)
+      h=0 if h==360
       @h, @s, @b = @hsb = validate_hsb([h, s, b])
     end
     alias :hue :h
@@ -300,6 +301,6 @@ module Colorable
       } || begin
         raise ArgumentError, "'#{name}' is not in X11 colorset."
       end
-    end 
+    end
   end
-end  
+end

--- a/lib/colorable/color_space.rb
+++ b/lib/colorable/color_space.rb
@@ -17,7 +17,7 @@ module Colorable
     end
 
     def -(arg)
-      arg = arg.is_a?(Fixnum) ? -arg : arg.map(&:-@)
+      arg = arg.is_a?(Integer) ? -arg : arg.map(&:-@)
       self + arg
     end
 
@@ -55,7 +55,7 @@ module Colorable
     # +other+ can be:
     #   RGB object: apply minimum compositing.
     #   Array of RGB values: each values added to each of RGBs.
-    #   Fixnum: other number added to all of RGBs.
+    #   Integer: other number added to all of RGBs.
     def +(other)
       rgb =
         case other
@@ -64,7 +64,7 @@ module Colorable
         when Array
           raise ArgumentError, "Invalid size of Array given" unless other.size==3
           compound_by(other) { |a, b| (a + b) % 256 }
-        when Fixnum
+        when Integer
           compound_by([other] * 3) { |a, b| (a + b) % 256 }
         else
           raise ArgumentError, "Invalid argument given"
@@ -77,7 +77,7 @@ module Colorable
     # +other+ can be:
     #   RGB object: apply maximum compositing.
     #   Array of RGB values: each values added to each of RGBs.
-    #   Fixnum: other number added to all of RGBs.
+    #   Integer: other number added to all of RGBs.
     def -(other)
       case other
       when RGB
@@ -141,7 +141,7 @@ module Colorable
     alias :to_a :hsb
     undef :coerce
 
-    # Pass Array of [h, s, b] or a Fixnum.
+    # Pass Array of [h, s, b] or a Integer.
     # Returns new HSB object with added HSB.
     def +(arg)
       arg =
@@ -232,12 +232,12 @@ module Colorable
     def build_hex_with(op, arg)
       _rgb =
         case arg
-        when Fixnum
+        when Integer
           [arg] * 3
         when String
           hex2rgb(validate_hex arg)
         else
-          raise ArgumentError, "Accept only a Hex string or a Fixnum"
+          raise ArgumentError, "Accept only a Hex string or a Integer"
         end 
       rgb = hex2rgb(self.hex).zip(_rgb).map { |x, y| (x.send(op, y)) % 256 }
       self.class.new rgb2hex(rgb)
@@ -267,13 +267,13 @@ module Colorable
     end
 
     def +(n)
-      raise ArgumentError, 'Only accept a Fixnum' unless n.is_a?(Fixnum)
+      raise ArgumentError, 'Only accept a Integer' unless n.is_a?(Integer)
       pos = COLORNAMES.find_index{|n,_| n==self.name} + n
       self.class.new COLORNAMES.at(pos % COLORNAMES.size)[0]
     end
 
     def -(n)
-      raise ArgumentError, 'Only accept a Fixnum' unless n.is_a?(Fixnum)
+      raise ArgumentError, 'Only accept a Integer' unless n.is_a?(Integer)
       self + -n
     end
 

--- a/spec/color_space_spec.rb
+++ b/spec/color_space_spec.rb
@@ -51,7 +51,7 @@ describe RGB do
       end
     end
 
-    context "pass a Fixnum" do
+    context "pass a Integer" do
       before(:all) { @rgb = RGB.new(100, 100, 100) }
       it { (@rgb + 50).rgb.should eql [150, 150, 150] }
       it "not raise ArgumentError" do
@@ -59,7 +59,7 @@ describe RGB do
       end
     end
 
-    context "coerce make Fixnum#+ accept rgb object" do
+    context "coerce make Integer#+ accept rgb object" do
       it { (10 + RGB.new(100, 100, 100)).rgb.should eql [110, 110, 110] }
     end
 
@@ -93,7 +93,7 @@ describe RGB do
       end
     end
 
-    context "pass a Fixnum" do
+    context "pass a Integer" do
       before(:all) { @rgb = RGB.new(100, 100, 100) }
       it { (@rgb - 50).rgb.should eql [50, 50, 50] }
       it "not raise ArgumentError" do
@@ -270,13 +270,13 @@ describe NAME do
       end
     end
 
-    context "pass a Fixnum" do
+    context "pass a Integer" do
       before(:all) { @name = NAME.new(:alice_blue) }
       it { (@name + 1).name.should eql 'Antique White' }
       it { (@name + 2).name.should eql 'Aqua' }
     end
 
-    context "coerce make Fixnum#+ accept name object" do
+    context "coerce make Integer#+ accept name object" do
       it { (1 + NAME.new(:alice_blue)).to_s.should eql 'Antique White' }
     end
   end
@@ -288,13 +288,13 @@ describe NAME do
       end
     end
 
-    context "pass a Fixnum" do
+    context "pass a Integer" do
       before(:all) { @name = NAME.new(:alice_blue) }
       it { (@name - 1).name.should eql 'Yellow Green' }
       it { (@name - 2).name.should eql 'Yellow' }
     end
 
-    context "coerce make Fixnum#+ accept name object" do
+    context "coerce make Integer#+ accept name object" do
       it { (1 - NAME.new(:alice_blue)).to_s.should eql 'Yellow Green' }
     end
   end
@@ -361,7 +361,7 @@ describe HEX do
       end
     end
 
-    context "pass a Fixnum" do
+    context "pass a Integer" do
       before(:all) { @hex = HEX.new('#000000') }
       it { (@hex + 255).hex.should eql '#FFFFFF' }
       it "not raise ArgumentError" do
@@ -369,7 +369,7 @@ describe HEX do
       end
     end
 
-    context "coerce make Fixnum#+ accept hex object" do
+    context "coerce make Integer#+ accept hex object" do
       it { (255 + HEX.new('#000000')).hex.should eql '#FFFFFF' }
     end
   end
@@ -397,7 +397,7 @@ describe HEX do
       end
     end
 
-    context "pass a Fixnum" do
+    context "pass a Integer" do
       before(:all) { @hex = HEX.new('#FFFFFF') }
       it { (@hex - 255).hex.should eql '#000000' }
       it "not raise ArgumentError" do
@@ -405,7 +405,7 @@ describe HEX do
       end
     end
 
-    context "coerce make Fixnum#+ accept hex object" do
+    context "coerce make Integer#+ accept hex object" do
       it { (255 - HEX.new('#FFFFFF')).hex.should eql '#000000' }
     end
   end

--- a/spec/colorable_spec.rb
+++ b/spec/colorable_spec.rb
@@ -51,14 +51,14 @@ describe Colorable do
     end
   end
 
-  describe "Fixnum#to_color" do
-    context "apply a hex Fixnum" do
+  describe "Integer#to_color" do
+    context "apply a hex Integer" do
       subject { 0x32CD32.to_color }
       it { should be_instance_of Colorable::Color }
       its(:to_s) { should eql "#32CD32" }
     end
 
-    context "apply a invalid Fixnum" do
+    context "apply a invalid Integer" do
       it "raise ArgumentError" do
         expect { 323232.to_color }.to raise_error ArgumentError
       end


### PR DESCRIPTION
Ruby 2.4 unified Fixnum and Bignum into Integer:
https://bugs.ruby-lang.org/issues/12005

Fixnum has since then been deprecated.